### PR TITLE
Fake sender id on MacOS notification

### DIFF
--- a/lib/notifier.coffee
+++ b/lib/notifier.coffee
@@ -67,6 +67,7 @@ module.exports =
             'message': message
             'icon': "#{icon}-#{type.toLowerCase()}.png"
             'contentImage': contentImage
+            'sender': 'com.github.atom'
         notifier.notify(params)
 
     deactivate: ->

--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
     "atom": ">=1.0.0 <2.0.0"
   },
   "dependencies": {
-    "node-notifier": "^4.4.0"
+    "node-notifier": "^5.2.0"
   }
 }


### PR DESCRIPTION
Hello @benjamindean 
This is a minor improvement that affects only MacOS native notifications.

It uses a ```terminal-notifier``` feature documented in https://github.com/julienXX/terminal-notifier#options

| Before | After |
| -- | -- |
| <img width="333" alt="before - final" src="https://user-images.githubusercontent.com/6209647/37612859-a848bdcc-2ba6-11e8-95f6-eac8ae2ad4e2.png"> | <img width="333" alt="after - final" src="https://user-images.githubusercontent.com/6209647/37612858-a81ab1b6-2ba6-11e8-947d-51fa034854b5.png"> |

Tested with Atom 1.25 on MacOS 10.13.3