### PR TITLE
Linted README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,31 +2,31 @@
 
 Native desktop notifications for Atom with [node-notifier](https://github.com/mikaelbr/node-notifier).  
 
-[Atom.io](https://atom.io/packages/atom-notifier)  | [GitHub](https://github.com/benjamindean/atom-notifier)
+[Atom.io](https://atom.io/packages/atom-notifier)  \| [GitHub](https://github.com/benjamindean/atom-notifier)
 
 `apm install atom-notifier`
 
 ![atom-notifier](https://cloud.githubusercontent.com/assets/5139993/8745652/c1d9597c-2c8a-11e5-8c10-c8ed3af6722f.png)
 
-##Currently tested on:
+## Currently tested on:
 
-- [x] Arch Linux (GNOME 3.16)
-- [x] Arch Linux (KDE Plasma 5)
-- [x] Ubuntu 15.04 (Unity)
-- [x] Windows 8
-- [x] Windows 7
-- [x] Windows XP
+-   [x] Arch Linux (GNOME 3.16)
+-   [x] Arch Linux (KDE Plasma 5)
+-   [x] Ubuntu 15.04 (Unity)
+-   [x] Windows 8
+-   [x] Windows 7
+-   [x] Windows XP
 
-##Options
+## Options
 
 This package doesn't watch for option changes. To apply new settings, reload editor with <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>R</kbd>.
 
-- Show only when editor is unfocused  
-Description: Show desktop notifications only when editor is unfocused or minimized.  
-Default: false
+-   Show only when editor is unfocused  
+    Description: Show desktop notifications only when editor is unfocused or minimized.  
+    Default: false
 
-- Show editor notifications?  
-Description: Which notifications to show in editor window.  
-Default: 'Show All'  
-Available: 'Show All', 'Show Errors and Fatal Errors', 'Hide All'  
-NOTE: Some notifications has buttons or large description text, so, better to leave this option as "Show All" or "Show Errors and Fatal Errors".
+-   Show editor notifications?  
+    Description: Which notifications to show in editor window.  
+    Default: 'Show All'  
+    Available: 'Show All', 'Show Errors and Fatal Errors', 'Hide All'  
+    NOTE: Some notifications has buttons or large description text, so, better to leave this option as "Show All" or "Show Errors and Fatal Errors".


### PR DESCRIPTION
I fixed the Readme making it compliant with the GitHub Flavored Markdown Spec.

| Before | After |
| -- | -- |
| ![before - final](https://user-images.githubusercontent.com/6209647/37613978-bd821154-2ba9-11e8-8a3c-25ff25fae151.png) | ![after - final](https://user-images.githubusercontent.com/6209647/37613977-bd5b099c-2ba9-11e8-9a7a-9494cfdcefde.png) |

