### PR TITLE
Fake appID on Windows 10 notification

### DIFF
--- a/lib/notifier.coffee
+++ b/lib/notifier.coffee
@@ -68,6 +68,7 @@ module.exports =
             'icon': "#{icon}-#{type.toLowerCase()}.png"
             'contentImage': contentImage
             'sender': 'com.github.atom'
+            'appID': 'com.squirrel.atom.atom'
         notifier.notify(params)
 
     deactivate: ->


### PR DESCRIPTION
Hello @benjamindean 
I'm here again!
This is a follow up of #9 , but for windows.

|Before| After|
|--|--|
| ![before - final](https://user-images.githubusercontent.com/6209647/41988990-27460518-7a3e-11e8-9e82-6b4319374e4b.png)| ![after - final](https://user-images.githubusercontent.com/6209647/41988991-276bd388-7a3e-11e8-8253-f37b02488cf5.png) |

Still, any other platform remains unaffected.

References:
https://github.com/Squirrel/Squirrel.Windows/issues/1338#issuecomment-397689514
https://github.com/mikaelbr/node-notifier#usage-windowstoaster